### PR TITLE
fix(deps): Helix Patch dependency bumps (11 packages)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6918,9 +6918,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.0.0.tgz",
-      "integrity": "sha512-GAWaqWlTjYK/7SVpIUA6CTxmcg65SP30sbjdCvyYReosRkk7Z/LyHWwkK3Vu0FcIi0FNTADUs4eh1AsU5s10cg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "requires": {
         "isarray": "0.0.1"
       },
@@ -7247,9 +7247,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="
     },
     "querystring": {
       "version": "0.2.0",


### PR DESCRIPTION
Opened by **Helix Patch**.

Bump packages where Trivy reported a fixed version:

- `brace-expansion`: `1.1.11` → `5.0.9` (CVE-2026-13149, CVE-2026-14257, CVE-2026-69152, CVE-2026-33750, CVE-2025-5889)
- `debug`: `4.1.1` → `4.3.1` (CVE-2017-16137)
- `follow-redirects`: `1.15.6` → `1.16.0` (GHSA-r4q5-vmmm-2653)
- `minimist`: `1.2.0` → `1.2.6` (CVE-2021-44906, CVE-2020-7598, CVE-2021-44906)
- `path-to-regexp`: `8.0.0` → `8.4.0` (CVE-2026-4926, CVE-2026-4923)
- `phin`: `2.9.3` → `3.7.1` (GHSA-x565-32qp-m3vf)
- `qs`: `6.14.1` → `6.15.2` (CVE-2026-8723, CVE-2026-2391)
- `semver`: `4.3.6` → `7.5.2` (CVE-2022-25883, CVE-2022-25883)
- `tar`: `6.1.13` → `7.5.21` (CVE-2026-59873, CVE-2026-23745, CVE-2026-23950, CVE-2026-24842, CVE-2026-26960, CVE-2026-29786, CVE-2026-31802, CVE-2026-59874, CVE-2024-28863, CVE-2026-53655, CVE-2026-59871, CVE-2026-59875, GHSA-r292-9mhp-454m)
- `uuid`: `3.3.2` → `13.0.1` (CVE-2026-41907)
- `xml2js`: `0.4.19` → `0.5.0` (CVE-2023-0842)

Please run your package manager install if the lockfile needs a refresh, then review CI.